### PR TITLE
Adicionar entidade de payment e integrá-la com Order

### DIFF
--- a/src/main/java/com/aprimorapring/aprimora/config/TestConfig.java
+++ b/src/main/java/com/aprimorapring/aprimora/config/TestConfig.java
@@ -145,5 +145,16 @@ public class TestConfig implements CommandLineRunner {
         OrderItem oi4 = new OrderItem(o3, p5, 2, p5.getPrice());
 
         orderItemRepository.saveAll(Arrays.asList(oi1, oi2, oi3, oi4));
+
+        Payment pay1 = new Payment().builder()
+                .id(null)
+                .moment(Instant.parse("2019-06-20T21:53:07Z"))
+                .order(o1)
+                .build();
+
+        o1.setPayment(pay1);
+
+        orderRepository.save(o1);
+
     }
 }

--- a/src/main/java/com/aprimorapring/aprimora/entities/Order.java
+++ b/src/main/java/com/aprimorapring/aprimora/entities/Order.java
@@ -38,5 +38,8 @@ public class Order implements Serializable {
 
     @OneToMany(mappedBy = "id.order")
     private Set<OrderItem> items = new HashSet<>();
+
+    @OneToOne(mappedBy = "order", cascade = CascadeType.ALL)
+    private Payment payment;
 }
 

--- a/src/main/java/com/aprimorapring/aprimora/entities/Payment.java
+++ b/src/main/java/com/aprimorapring/aprimora/entities/Payment.java
@@ -1,0 +1,31 @@
+package com.aprimorapring.aprimora.entities;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.time.Instant;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+@EqualsAndHashCode
+@Builder
+@Entity
+@Table(name = "tb_payment")
+public class Payment implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private Instant moment;
+
+    @OneToOne
+    @MapsId
+    private Order order;
+}


### PR DESCRIPTION
Introduzida uma nova entidade de Payment com as devidas anotações JPA e suporte do Lombok. Modificada a entidade Order para estabelecer uma relação um-para-um com Payment, incluindo operações em cascata. Atualizado TestConfig para incluir a inicialização de dados de Pagamento e persistir juntamente com as ordens associadas.