### PR TITLE
Adicione tratamento global de exceção para ResourceNotFoundException

### DIFF
--- a/src/main/java/com/aprimorapring/aprimora/controller/exceptions/ResourceExceptionHandler.java
+++ b/src/main/java/com/aprimorapring/aprimora/controller/exceptions/ResourceExceptionHandler.java
@@ -1,0 +1,22 @@
+package com.aprimorapring.aprimora.controller.exceptions;
+
+import com.aprimorapring.aprimora.services.exceptions.ResourceNotFoundException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import java.time.Instant;
+
+@ControllerAdvice
+public class ResourceExceptionHandler extends RuntimeException {
+
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<StandardError> resourceNotFound(ResourceNotFoundException e, HttpServletRequest request) {
+        String erro = "Resource not found for ";
+        HttpStatus status = HttpStatus.NOT_FOUND;
+        StandardError err = new StandardError(Instant.now(), status.value(), erro, e.getMessage(), request.getRequestURI());
+        return ResponseEntity.status(status).body(err);
+    }
+}

--- a/src/main/java/com/aprimorapring/aprimora/controller/exceptions/StandardError.java
+++ b/src/main/java/com/aprimorapring/aprimora/controller/exceptions/StandardError.java
@@ -1,0 +1,29 @@
+package com.aprimorapring.aprimora.controller.exceptions;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.time.Instant;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class StandardError implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'", timezone = "GMT")
+    private Instant timestamp;
+    private Integer status;
+    private String error;
+    private String message;
+    private String path;
+
+
+}

--- a/src/main/java/com/aprimorapring/aprimora/services/UserService.java
+++ b/src/main/java/com/aprimorapring/aprimora/services/UserService.java
@@ -2,6 +2,7 @@ package com.aprimorapring.aprimora.services;
 
 import com.aprimorapring.aprimora.entities.User;
 import com.aprimorapring.aprimora.repositories.UserRepository;
+import com.aprimorapring.aprimora.services.exceptions.ResourceNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,7 +21,7 @@ public class UserService {
 
     public User findById(Long id) {
         Optional<User> obj = repository.findById(id);
-        return obj.get();
+        return obj.orElseThrow(() -> new ResourceNotFoundException(id));
     }
 
     public User insert(User user) {

--- a/src/main/java/com/aprimorapring/aprimora/services/exceptions/ResourceNotFoundException.java
+++ b/src/main/java/com/aprimorapring/aprimora/services/exceptions/ResourceNotFoundException.java
@@ -1,0 +1,8 @@
+package com.aprimorapring.aprimora.services.exceptions;
+
+public class ResourceNotFoundException extends RuntimeException {
+
+    public ResourceNotFoundException(Object id) {
+        super("Recursos não encontrados para o " + id);
+    }
+}


### PR DESCRIPTION
Introduziu `ResourceExceptionHandler` para lidar com `ResourceNotFoundException` com um formato de resposta de erro padronizado utilizando `StandardError`. Atualizou `UserService` para lançar `ResourceNotFoundException` quando um ID de usuário não é encontrado. Isso garante uma melhor gestão de erros em toda a aplicação.